### PR TITLE
Restart nginx even if certbot fails

### DIFF
--- a/certbot-nginx.service
+++ b/certbot-nginx.service
@@ -6,4 +6,4 @@ After=network-online.target
 Type=oneshot
 ExecStartPre=/bin/systemctl stop nginx
 ExecStart=/usr/bin/certbot renew --standalone
-ExecStartPost=/bin/systemctl --no-block start nginx
+ExecStopPost=/bin/systemctl --no-block start nginx


### PR DESCRIPTION
I recently had a problem with the certbot-nginx unit. It seems that certbot has failed and `ExecStartPost` hasn't been executed, so my website was down for a few hours. According to the manual, `ExecStopPost` is executed even if the unit fails. That works on my machine.